### PR TITLE
Remove unmatched div

### DIFF
--- a/src/components/Todos/TodoItem/EditTodo/EditTodo.vue
+++ b/src/components/Todos/TodoItem/EditTodo/EditTodo.vue
@@ -23,7 +23,6 @@
           <textarea ref="textarea" rows="1" id="edit-textarea" v-model="value"
             v-on:keydown.enter.prevent='attemptUpdate'></textarea>
         </div>
-        <div>
       </div>
 
     </div>


### PR DESCRIPTION
This dangling div causes the command `npm run hot` to throw:

```
ERROR in ./~/vue-loader/lib/template-compiler.js?id=data-v-f059d76a!./~/vue-loader/lib/selector.js?type=template&index=0!./src/components/Todos/TodoItem/EditTodo/EditTodo.vue

  Vue template syntax error:

  tag <div> has no matching end tag.

webpack: Failed to compile.
```